### PR TITLE
Add Jira integration with magic command and utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.2.5](https://github.com/madpin/cellmage/releases/tag/v0.2.5) - 2025-04-29
+
 ## [v0.2.4](https://github.com/madpin/cellmage/releases/tag/v0.2.4) - 2025-04-29
 
 ## [v0.2.3](https://github.com/madpin/cellmage/releases/tag/v0.2.3) - 2025-04-29

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,14 @@ docs :
 .PHONY : run-checks
 run-checks :
 	isort --check .
-	black --check .
-	ruff check .
-	mypy .
+	black --config pyproject.toml --check .
+	ruff  --config pyproject.toml check .
 	CUDA_VISIBLE_DEVICES='' pytest -v --color=yes --doctest-modules tests/ cellmage/
 
 run-fix :
 	isort .
-	black .
-	ruff format
+	black --config pyproject.toml .
+	ruff --config pyproject.toml format
 	CUDA_VISIBLE_DEVICES='' pytest -v --color=yes --doctest-modules tests/ cellmage/
 
 .PHONY : build

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It's designed for **data scientists, software engineers, researchers, and studen
 *   **🎭 Personas:** Define and switch between different AI personalities (e.g., 'code_reviewer', 'data_analyst', 'rubber_duck_debugger').
 *   **🔮 Ambient Mode:** Optionally turn your entire notebook into an LLM chat interface.
 *   **✂️ Snippets:** Inject reusable code or text snippets into your prompts on the fly.
+*   **📋 Jira Integration:** Fetch Jira tickets directly as context for your LLM prompts with the `%jira` command.
 *   **💾 History & Session Management:** Automatically track conversations, save/load sessions to Markdown, and manage context.
 *   **⚙️ Flexible Configuration:** Customize models, parameters (like `temperature`), and behavior via commands or environment variables.
 *   **🧩 Adapter System:** Supports different LLM backends (currently Direct OpenAI-compatible API access, with LangChain integration).
@@ -40,6 +41,12 @@ pip install cellmage
 
 ```bash
 pip install "cellmage[langchain]"
+```
+
+*(Optional)* To use the Jira integration, install with the jira extras:
+
+```bash
+pip install "cellmage[jira]"
 ```
 
 *(Optional)* For development or to get the latest code, install from source:
@@ -107,6 +114,19 @@ pip install -e .[dev] # Includes dev dependencies
     %llm_config --clear-history
     ```
     *(Run `%llm_config --help` for all options!)*
+
+*   `%jira`: Fetches Jira tickets and adds them as context for LLM prompts.
+    ```python
+    # Fetch a specific ticket
+    %jira PROJECT-123
+    
+    # Use JQL to fetch multiple tickets
+    %jira --jql "project = PROJECT AND assignee = currentUser()" --max 3
+    
+    # Add as system message instead of user message
+    %jira PROJECT-123 --system
+    ```
+    *(Requires installing the `jira` extras: `pip install "cellmage[jira]"`)*
 
 ### 2. Personas (Your AI's Identities)
 
@@ -188,7 +208,32 @@ Inject files as context (e.g., code definitions, instructions) into your prompts
     *(Snippets added via `%llm_config` persist until cleared or new snippets are added.)*
     *You can also add snippets per-cell using `%%llm --snippet ...`.*
 
-### 5. Session Management (Saving Your Work)
+### 5. Jira Integration (Project Context)
+
+Fetch Jira tickets directly as context for your LLM prompts.
+
+*   **Setup:**
+    ```
+    # Install with Jira extras
+    pip install "cellmage[jira]"
+    
+    # Set environment variables (in your .env file or directly)
+    JIRA_URL=https://your-company.atlassian.net
+    JIRA_USER_EMAIL=your.email@example.com
+    JIRA_API_TOKEN=your-jira-api-token
+    ```
+
+*   **Using with LLM prompts:**
+    ```python
+    # First, fetch a ticket
+    %jira PROJECT-123
+    
+    # Then ask the LLM about it
+    %%llm
+    Based on the Jira ticket above, write a Python function that implements the requirements.
+    ```
+
+### 6. Session Management (Saving Your Work)
 
 Cellmage automatically saves conversations if an `llm_conversations` directory exists. You can also manually save/load.
 
@@ -212,6 +257,8 @@ Cellmage is configured via:
 1.  **Environment Variables:** (Prefix `CELLMAGE_`) - e.g., `CELLMAGE_API_KEY`, `CELLMAGE_DEFAULT_MODEL`, `CELLMAGE_PERSONAS_DIRS`. Recommended for secrets.
 2.  **`.env` File:** Place a `.env` file in your working directory.
 3.  **Magic Commands:** `%llm_config` allows runtime changes.
+
+For Jira integration, set `JIRA_URL`, `JIRA_USER_EMAIL`, and `JIRA_API_TOKEN` environment variables.
 
 *(See `config.py` or documentation for all options.)*
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ It's designed for **data scientists, software engineers, researchers, and studen
 *   **🎭 Personas:** Define and switch between different AI personalities (e.g., 'code_reviewer', 'data_analyst', 'rubber_duck_debugger').
 *   **🔮 Ambient Mode:** Optionally turn your entire notebook into an LLM chat interface.
 *   **✂️ Snippets:** Inject reusable code or text snippets into your prompts on the fly.
-*   **📋 Jira Integration:** Fetch Jira tickets directly as context for your LLM prompts with the `%jira` command.
 *   **💾 History & Session Management:** Automatically track conversations, save/load sessions to Markdown, and manage context.
 *   **⚙️ Flexible Configuration:** Customize models, parameters (like `temperature`), and behavior via commands or environment variables.
 *   **🧩 Adapter System:** Supports different LLM backends (currently Direct OpenAI-compatible API access, with LangChain integration).
 *   **🏷️ Model Mapping:** Use short aliases (like `g4o`) for full model names (`gpt-4o`).
 *   **📊 Status & Cost Tracking:** Get immediate feedback on prompt execution time, token usage, and estimated cost.
+*   **🔄 Jira Integration:** Fetch Jira tickets directly into your notebook to use as context for your LLM queries.
 
 ---
 
@@ -41,12 +41,6 @@ pip install cellmage
 
 ```bash
 pip install "cellmage[langchain]"
-```
-
-*(Optional)* To use the Jira integration, install with the jira extras:
-
-```bash
-pip install "cellmage[jira]"
 ```
 
 *(Optional)* For development or to get the latest code, install from source:
@@ -114,19 +108,6 @@ pip install -e .[dev] # Includes dev dependencies
     %llm_config --clear-history
     ```
     *(Run `%llm_config --help` for all options!)*
-
-*   `%jira`: Fetches Jira tickets and adds them as context for LLM prompts.
-    ```python
-    # Fetch a specific ticket
-    %jira PROJECT-123
-    
-    # Use JQL to fetch multiple tickets
-    %jira --jql "project = PROJECT AND assignee = currentUser()" --max 3
-    
-    # Add as system message instead of user message
-    %jira PROJECT-123 --system
-    ```
-    *(Requires installing the `jira` extras: `pip install "cellmage[jira]"`)*
 
 ### 2. Personas (Your AI's Identities)
 
@@ -208,32 +189,7 @@ Inject files as context (e.g., code definitions, instructions) into your prompts
     *(Snippets added via `%llm_config` persist until cleared or new snippets are added.)*
     *You can also add snippets per-cell using `%%llm --snippet ...`.*
 
-### 5. Jira Integration (Project Context)
-
-Fetch Jira tickets directly as context for your LLM prompts.
-
-*   **Setup:**
-    ```
-    # Install with Jira extras
-    pip install "cellmage[jira]"
-    
-    # Set environment variables (in your .env file or directly)
-    JIRA_URL=https://your-company.atlassian.net
-    JIRA_USER_EMAIL=your.email@example.com
-    JIRA_API_TOKEN=your-jira-api-token
-    ```
-
-*   **Using with LLM prompts:**
-    ```python
-    # First, fetch a ticket
-    %jira PROJECT-123
-    
-    # Then ask the LLM about it
-    %%llm
-    Based on the Jira ticket above, write a Python function that implements the requirements.
-    ```
-
-### 6. Session Management (Saving Your Work)
+### 5. Session Management (Saving Your Work)
 
 Cellmage automatically saves conversations if an `llm_conversations` directory exists. You can also manually save/load.
 
@@ -248,6 +204,48 @@ Cellmage automatically saves conversations if an `llm_conversations` directory e
 %llm_config --list-sessions
 ```
 
+### 6. Jira Integration
+
+Connect your notebooks directly to Jira tickets using the `%jira` magic command.
+
+*   **Installation:**
+    ```bash
+    pip install "cellmage[jira]"
+    ```
+
+*   **Configuration:**
+    Set these environment variables in a `.env` file or your environment:
+    ```
+    JIRA_URL=https://your-company.atlassian.net
+    JIRA_USER_EMAIL=your.email@company.com
+    JIRA_API_TOKEN=your_jira_api_token
+    ```
+
+*   **Basic Usage:**
+    ```python
+    # Fetch a specific ticket and add it to chat history
+    %jira PROJECT-123
+
+    # Fetch a ticket and add as system context
+    %jira PROJECT-123 --system
+
+    # Just display a ticket without adding to history
+    %jira PROJECT-123 --show
+
+    # Use JQL to fetch multiple tickets
+    %jira --jql 'assignee = currentUser() ORDER BY updated DESC' --max 5
+    ```
+
+*   **Using with LLM Queries:**
+    ```python
+    # First, fetch the ticket
+    %jira PROJECT-123
+
+    # Then, reference it in your prompt
+    %%llm
+    Given the Jira ticket above, what are the key requirements I need to implement?
+    ```
+
 ---
 
 ## ⚙️ Configuration
@@ -257,8 +255,6 @@ Cellmage is configured via:
 1.  **Environment Variables:** (Prefix `CELLMAGE_`) - e.g., `CELLMAGE_API_KEY`, `CELLMAGE_DEFAULT_MODEL`, `CELLMAGE_PERSONAS_DIRS`. Recommended for secrets.
 2.  **`.env` File:** Place a `.env` file in your working directory.
 3.  **Magic Commands:** `%llm_config` allows runtime changes.
-
-For Jira integration, set `JIRA_URL`, `JIRA_USER_EMAIL`, and `JIRA_API_TOKEN` environment variables.
 
 *(See `config.py` or documentation for all options.)*
 

--- a/cellmage/integrations/__init__.py
+++ b/cellmage/integrations/__init__.py
@@ -1,28 +1,10 @@
 """
-Integration components for various environments.
+Integration modules for CellMage.
 
-This module contains integrations with environments like IPython/Jupyter,
-including magics and context providers.
+This package contains modules that integrate CellMage with other systems.
 """
 
-try:
-    from ..context_providers.ipython_context_provider import IPythonContextProvider
-    from .ipython_magic import (
-        NotebookLLMMagics,
-        load_ipython_extension,
-        unload_ipython_extension,
-    )
+# Import the IPython magic modules for easy access
+from . import ipython_magic, jira_magic
 
-    _IPYTHON_AVAILABLE = True
-except ImportError:
-    _IPYTHON_AVAILABLE = False
-
-if _IPYTHON_AVAILABLE:
-    __all__ = [
-        "IPythonContextProvider",
-        "NotebookLLMMagics",
-        "load_ipython_extension",
-        "unload_ipython_extension",
-    ]
-else:
-    __all__ = []
+__all__ = ["ipython_magic", "jira_magic"]

--- a/cellmage/integrations/ipython_magic.py
+++ b/cellmage/integrations/ipython_magic.py
@@ -1226,12 +1226,26 @@ def load_ipython_extension(ipython):
         print("IPython is not available. Cannot load NotebookLLM magics.", file=sys.stderr)
         return
     try:
+        # Load main magics
         magic_class = NotebookLLMMagics(ipython)
         ipython.register_magics(magic_class)
         print("✅ NotebookLLM Magics loaded. Use %llm_config and %%llm.")
         print(
             "   For ambient mode, try %llm_config_persistent to process all cells as LLM prompts."
         )
+
+        # Try to load Jira magic if available
+        try:
+            from . import jira_magic
+
+            jira_magic.load_ipython_extension(ipython)
+        except ImportError:
+            logger.info(
+                "Jira integration not available. Install with 'pip install cellmage[jira]' to enable."
+            )
+        except Exception as e:
+            logger.warning(f"Failed to load Jira magic: {e}")
+
     except Exception as e:
         logger.exception("Failed to register NotebookLLM magics.")
         print(f"❌ Failed to load NotebookLLM Magics: {e}", file=sys.stderr)

--- a/cellmage/integrations/jira_magic.py
+++ b/cellmage/integrations/jira_magic.py
@@ -4,15 +4,12 @@ IPython magic command for Jira integration with CellMage.
 This module provides magic commands for fetching Jira tickets and using them as context in LLM prompts.
 """
 
-import json
 import logging
-import os
 import sys
 from typing import Any, Dict, List, Optional
 
 # IPython imports with fallback handling
 try:
-    from IPython import get_ipython
     from IPython.core.magic import Magics, line_magic, magics_class
     from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 
@@ -43,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # Attempt to import Jira utils
 try:
-    from functools import lru_cache
+    # from functools import lru_cache
 
     from jira import JIRA
 

--- a/cellmage/integrations/jira_magic.py
+++ b/cellmage/integrations/jira_magic.py
@@ -1,0 +1,446 @@
+"""
+IPython magic command for Jira integration with CellMage.
+
+This module provides magic commands for fetching Jira tickets and using them as context in LLM prompts.
+"""
+
+import json
+import logging
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+# IPython imports with fallback handling
+try:
+    from IPython import get_ipython
+    from IPython.core.magic import Magics, line_magic, magics_class
+    from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+
+    _IPYTHON_AVAILABLE = True
+except ImportError:
+    _IPYTHON_AVAILABLE = False
+
+    # Define dummy decorators if IPython is not installed
+    def magics_class(cls):
+        return cls
+
+    def line_magic(func):
+        return func
+
+    def magic_arguments():
+        return lambda func: func
+
+    def argument(*args, **kwargs):
+        return lambda func: func
+
+    class DummyMagics:
+        pass  # Dummy base class
+
+    Magics = DummyMagics  # Type alias for compatibility
+
+# Create a global logger
+logger = logging.getLogger(__name__)
+
+# Attempt to import Jira utils
+try:
+    from functools import lru_cache
+
+    from jira import JIRA
+
+    _JIRA_AVAILABLE = True
+except ImportError:
+    _JIRA_AVAILABLE = False
+
+
+@magics_class
+class JiraMagics(Magics):
+    """IPython magic commands for fetching and using Jira tickets as context."""
+
+    def __init__(self, shell):
+        if not _IPYTHON_AVAILABLE:
+            logger.warning("IPython not found. Jira magics are disabled.")
+            return
+
+        super().__init__(shell)
+        self.jira_client = None
+        self.jira_utils = None
+        self._init_jira_client()
+
+    def _init_jira_client(self) -> None:
+        """Initialize the Jira client if possible."""
+        if not _JIRA_AVAILABLE:
+            logger.warning("Jira package not available. Please install the jira package.")
+            return
+
+        try:
+            # Import required modules for Jira utils
+            import os
+
+            from dotenv import load_dotenv
+
+            # Load environment variables
+            load_dotenv()
+
+            # Check for required environment variables
+            jira_url = os.getenv("JIRA_URL")
+            jira_user = os.getenv("JIRA_USER_EMAIL")
+            jira_token = os.getenv("JIRA_API_TOKEN")
+
+            if not jira_url or not jira_user or not jira_token:
+                logger.warning(
+                    "Missing Jira environment variables. Please set JIRA_URL, JIRA_USER_EMAIL, and JIRA_API_TOKEN."
+                )
+                return
+
+            # Try to initialize JiraUtils
+            try:
+                from ..utils.jira_utils import JiraUtils
+
+                self.jira_utils = JiraUtils(
+                    user_email=jira_user, api_token=jira_token, jira_url=jira_url
+                )
+                logger.info(f"JiraUtils initialized successfully for {jira_url}")
+            except Exception as e:
+                logger.error(f"Failed to initialize JiraUtils: {e}")
+                # Fallback to basic JIRA client if JiraUtils fails
+                try:
+                    self.jira_client = JIRA(server=jira_url, basic_auth=(jira_user, jira_token))
+                    logger.info(f"Basic JIRA client initialized successfully for {jira_url}")
+                except Exception as e:
+                    logger.error(f"Failed to initialize basic JIRA client: {e}")
+        except Exception as e:
+            logger.error(f"Error during Jira client initialization: {e}")
+
+    def _get_client(self):
+        """Get the JiraUtils instance or JIRA client, initializing if needed."""
+        if self.jira_utils is not None:
+            return self.jira_utils
+
+        if self.jira_client is not None:
+            return self.jira_client
+
+        self._init_jira_client()
+
+        if self.jira_utils is not None:
+            return self.jira_utils
+
+        if self.jira_client is not None:
+            return self.jira_client
+
+        return None
+
+    def _fetch_ticket(self, ticket_key: str) -> Optional[Dict[str, Any]]:
+        """Fetch a Jira ticket by key and return processed data."""
+        client = self._get_client()
+
+        if client is None:
+            print("❌ Jira client not available")
+            return None
+
+        try:
+            # If we're using JiraUtils
+            if hasattr(client, "fetch_processed_ticket"):
+                return client.fetch_processed_ticket(ticket_key)
+
+            # If we're using basic JIRA client
+            issue = client.issue(ticket_key)
+
+            # Create a simplified dictionary with basic issue information
+            return {
+                "key": issue.key,
+                "summary": issue.fields.summary,
+                "description": issue.fields.description,
+                "status": (
+                    issue.fields.status.name
+                    if hasattr(issue.fields.status, "name")
+                    else str(issue.fields.status)
+                ),
+                "assignee": (
+                    issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned"
+                ),
+                "reporter": (
+                    issue.fields.reporter.displayName if issue.fields.reporter else "Unknown"
+                ),
+                "created_date": (
+                    str(issue.fields.created) if hasattr(issue.fields, "created") else None
+                ),
+                "updated_date": (
+                    str(issue.fields.updated) if hasattr(issue.fields, "updated") else None
+                ),
+            }
+        except Exception as e:
+            print(f"❌ Error fetching Jira ticket {ticket_key}: {e}")
+            logger.error(f"Error fetching Jira ticket {ticket_key}: {e}")
+            return None
+
+    def _fetch_tickets_by_jql(
+        self, jql: str, max_results: Optional[int] = 10
+    ) -> List[Dict[str, Any]]:
+        """Fetch Jira tickets by JQL query and return processed data."""
+        client = self._get_client()
+
+        if client is None:
+            print("❌ Jira client not available")
+            return []
+
+        try:
+            # If we're using JiraUtils
+            if hasattr(client, "fetch_processed_tickets"):
+                return client.fetch_processed_tickets(jql, max_results=max_results)
+
+            # If we're using basic JIRA client
+            issues = client.search_issues(jql, maxResults=max_results)
+
+            results = []
+            for issue in issues:
+                results.append(
+                    {
+                        "key": issue.key,
+                        "summary": issue.fields.summary,
+                        "description": issue.fields.description,
+                        "status": (
+                            issue.fields.status.name
+                            if hasattr(issue.fields.status, "name")
+                            else str(issue.fields.status)
+                        ),
+                        "assignee": (
+                            issue.fields.assignee.displayName
+                            if issue.fields.assignee
+                            else "Unassigned"
+                        ),
+                        "reporter": (
+                            issue.fields.reporter.displayName
+                            if issue.fields.reporter
+                            else "Unknown"
+                        ),
+                        "created_date": (
+                            str(issue.fields.created) if hasattr(issue.fields, "created") else None
+                        ),
+                        "updated_date": (
+                            str(issue.fields.updated) if hasattr(issue.fields, "updated") else None
+                        ),
+                    }
+                )
+
+            return results
+        except Exception as e:
+            print(f"❌ Error fetching Jira tickets with JQL '{jql}': {e}")
+            logger.error(f"Error fetching Jira tickets with JQL '{jql}': {e}")
+            return []
+
+    def _format_ticket_for_display(self, ticket: Dict[str, Any]) -> str:
+        """Format a ticket for terminal display."""
+        if not ticket:
+            return "No ticket data available"
+
+        # If using JiraUtils with full formatting
+        if (
+            hasattr(self, "jira_utils")
+            and self.jira_utils is not None
+            and hasattr(self.jira_utils, "format_tickets_for_llm")
+        ):
+            return self.jira_utils.format_tickets_for_llm(
+                [ticket], include_description=True, include_comments=True
+            )
+
+        # Basic formatting
+        output = []
+        output.append(f"# [{ticket.get('key', 'N/A')}] {ticket.get('summary', 'No Summary')}")
+        output.append(f"**Status:** {ticket.get('status', 'Unknown')}")
+        output.append(f"**Assignee:** {ticket.get('assignee', 'Unassigned')}")
+        output.append(f"**Reporter:** {ticket.get('reporter', 'Unknown')}")
+
+        if ticket.get("created_date"):
+            output.append(f"**Created:** {ticket.get('created_date')}")
+
+        if ticket.get("updated_date"):
+            output.append(f"**Updated:** {ticket.get('updated_date')}")
+
+        if ticket.get("description"):
+            desc = ticket.get("description")
+            output.append("\n**Description:**")
+            output.append(f"```\n{desc}\n```")
+
+        return "\n".join(output)
+
+    def _get_chat_manager(self):
+        """Get the ChatManager instance."""
+        try:
+            from ..integrations.ipython_magic import get_chat_manager
+
+            return get_chat_manager()
+        except Exception as e:
+            logger.error(f"Error getting ChatManager: {e}")
+            print(f"❌ Error getting ChatManager: {e}")
+            return None
+
+    def _add_ticket_to_history(
+        self, ticket_data: Dict[str, Any], as_system_msg: bool = False
+    ) -> bool:
+        """Add the ticket data to the chat history as a user or system message."""
+        import uuid
+
+        from ..models import Message
+
+        manager = self._get_chat_manager()
+        if not manager:
+            print("❌ ChatManager not available")
+            return False
+
+        try:
+            # Format ticket for LLM
+            if (
+                hasattr(self, "jira_utils")
+                and self.jira_utils is not None
+                and hasattr(self.jira_utils, "format_tickets_for_llm")
+            ):
+                content = self.jira_utils.format_tickets_for_llm(
+                    [ticket_data], include_description=True, include_comments=True
+                )
+            else:
+                # Basic formatting
+                content = self._format_ticket_for_display(ticket_data)
+
+            # Create message
+            role = "system" if as_system_msg else "user"
+            message = Message(
+                role=role,
+                content=content,
+                id=str(uuid.uuid4()),
+                metadata={"source": "jira", "jira_key": ticket_data.get("key", "")},
+            )
+
+            # Add to history
+            manager.history_manager.add_message(message)
+            print(
+                f"✅ Added Jira ticket {ticket_data.get('key', '')} as {role} message to chat history"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"Error adding ticket to history: {e}")
+            print(f"❌ Error adding ticket to history: {e}")
+            return False
+
+    @magic_arguments()
+    @argument("ticket", type=str, nargs="?", help="Jira ticket key (e.g., PROJECT-123)")
+    @argument("--jql", type=str, help="JQL query instead of a specific ticket key")
+    @argument("--max", type=int, default=5, help="Maximum number of tickets to retrieve with JQL")
+    @argument(
+        "--system",
+        action="store_true",
+        help="Add tickets as system messages instead of user messages",
+    )
+    @argument("--show", action="store_true", help="Only show tickets without adding to history")
+    @line_magic("jira")
+    def jira_magic(self, line):
+        """Fetch Jira ticket(s) and add them to the chat context.
+
+        Examples:
+            %jira PROJECT-123
+            %jira --jql "project = PROJECT AND assignee = currentUser()"
+            %jira PROJECT-123 --system
+            %jira --jql "project = PROJECT ORDER BY updated DESC" --max 3
+        """
+        if not _IPYTHON_AVAILABLE:
+            print("❌ IPython is not available. Cannot use %jira magic.")
+            return
+
+        if not _JIRA_AVAILABLE:
+            print(
+                "❌ Jira package not available. Please install with: pip install jira python-dotenv"
+            )
+            return
+
+        try:
+            args = parse_argstring(self.jira_magic, line)
+        except Exception as e:
+            print(f"❌ Error parsing arguments: {e}")
+            return
+
+        # Initialize client if needed
+        if self._get_client() is None:
+            print("❌ Jira client not available. Please check your environment variables.")
+            return
+
+        try:
+            # Fetch by JQL or specific ticket key
+            if args.jql:
+                # Clean up JQL query - remove outer quotes if present
+                cleaned_jql = args.jql.strip()
+                if (cleaned_jql.startswith("'") and cleaned_jql.endswith("'")) or (
+                    cleaned_jql.startswith('"') and cleaned_jql.endswith('"')
+                ):
+                    cleaned_jql = cleaned_jql[1:-1]
+
+                print(f"Fetching tickets with JQL: {cleaned_jql}")
+                tickets = self._fetch_tickets_by_jql(cleaned_jql, max_results=args.max)
+
+                if not tickets:
+                    print(f"No tickets found with JQL: {cleaned_jql}")
+                    return
+
+                print(f"Found {len(tickets)} tickets.")
+
+                # Display or add to history
+                for ticket in tickets:
+                    if args.show:
+                        print("\n" + self._format_ticket_for_display(ticket))
+                    else:
+                        self._add_ticket_to_history(ticket, as_system_msg=args.system)
+
+            elif args.ticket:
+                # Clean up ticket key - remove quotes if present
+                cleaned_ticket = args.ticket.strip()
+                if (cleaned_ticket.startswith("'") and cleaned_ticket.endswith("'")) or (
+                    cleaned_ticket.startswith('"') and cleaned_ticket.endswith('"')
+                ):
+                    cleaned_ticket = cleaned_ticket[1:-1]
+
+                print(f"Fetching ticket: {cleaned_ticket}")
+                ticket = self._fetch_ticket(cleaned_ticket)
+
+                if not ticket:
+                    print(f"No ticket found with key: {cleaned_ticket}")
+                    return
+
+                if args.show:
+                    print("\n" + self._format_ticket_for_display(ticket))
+                else:
+                    self._add_ticket_to_history(ticket, as_system_msg=args.system)
+
+            else:
+                print("❌ Please provide either a ticket key or a JQL query.")
+
+        except Exception as e:
+            print(f"❌ Error in Jira magic: {e}")
+            logger.error(f"Error in Jira magic: {e}", exc_info=True)
+
+
+# --- Extension Loading ---
+def load_ipython_extension(ipython):
+    """Register the Jira magics with the IPython runtime."""
+    if not _IPYTHON_AVAILABLE:
+        print("IPython is not available. Cannot load Jira magics.", file=sys.stderr)
+        return
+
+    if not _JIRA_AVAILABLE:
+        print(
+            "Jira package not found. Please install with: pip install jira python-dotenv",
+            file=sys.stderr,
+        )
+        print("Jira magics will not be available.", file=sys.stderr)
+        return
+
+    try:
+        magic_class = JiraMagics(ipython)
+        ipython.register_magics(magic_class)
+        print("✅ Jira Magics loaded. Use %jira <ticket-key> to fetch tickets.")
+    except Exception as e:
+        logger.exception("Failed to register Jira magics.")
+        print(f"❌ Failed to load Jira Magics: {e}", file=sys.stderr)
+
+
+def unload_ipython_extension(ipython):
+    """Unregister the magics."""
+    pass

--- a/cellmage/utils/__init__.py
+++ b/cellmage/utils/__init__.py
@@ -12,10 +12,29 @@ from .file_utils import (
 )
 from .logging import setup_logging
 
+# Import JiraUtils conditionally since it requires optional dependencies
+try:
+    from .jira_utils import JiraUtils
+
+    _JIRA_AVAILABLE = True
+except ImportError:
+    # Define a placeholder for better error messages when the dependency is missing
+    class JiraUtils:
+        """Placeholder for JiraUtils class when jira package is not installed."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "The 'jira' package is required to use JiraUtils. "
+                "Install it with 'pip install cellmage[jira]'"
+            )
+
+    _JIRA_AVAILABLE = False
+
 __all__ = [
     "setup_logging",
     "display_files_as_table",
     "display_files_paginated",
     "list_directory_files",
     "display_directory",
+    "JiraUtils",
 ]

--- a/cellmage/utils/jira_utils.py
+++ b/cellmage/utils/jira_utils.py
@@ -4,13 +4,11 @@ Jira utility for interacting with the Jira API.
 This module provides the JiraUtils class for fetching and processing Jira tickets.
 """
 
-import json
 import logging
-import math
 import os
 from collections import defaultdict
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple
 
 # Flag to check if Jira is available
 _JIRA_AVAILABLE = False

--- a/cellmage/utils/jira_utils.py
+++ b/cellmage/utils/jira_utils.py
@@ -153,9 +153,7 @@ class JiraUtils:
         self.epic_link_field_id = (
             epic_link_field_id
             if epic_link_field_id is not None
-            else _env_epic_field
-            if _env_epic_field is not None
-            else DEFAULT_EPIC_LINK_FIELD_ID
+            else _env_epic_field if _env_epic_field is not None else DEFAULT_EPIC_LINK_FIELD_ID
         )
 
         # Validate essential configuration

--- a/cellmage/utils/jira_utils.py
+++ b/cellmage/utils/jira_utils.py
@@ -1,0 +1,745 @@
+"""
+Jira utility for interacting with the Jira API.
+
+This module provides the JiraUtils class for fetching and processing Jira tickets.
+"""
+
+import json
+import logging
+import math
+import os
+from collections import defaultdict
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+
+# Flag to check if Jira is available
+_JIRA_AVAILABLE = False
+
+try:
+    from jira import JIRA, Issue
+    from jira.exceptions import JIRAError
+    from jira.resources import Comment as JiraCommentResource  # For type hinting
+
+    _JIRA_AVAILABLE = True
+except ImportError:
+    # Define placeholder types for type checking when jira package is not available
+    if TYPE_CHECKING:
+        from jira import JIRA, Issue
+        from jira.exceptions import JIRAError
+        from jira.resources import Comment as JiraCommentResource
+    else:
+        JIRA = object
+        Issue = object
+        JIRAError = Exception
+        JiraCommentResource = object
+
+# --- Constants ---
+DEFAULT_JIRA_URL: str = "https://jira.atlassian.net"
+DEFAULT_EPIC_LINK_FIELD_ID: str = "customfield_10014"  # Default for most Jira instances
+DEFAULT_MAX_RESULTS_PER_PAGE: int = 50  # Recommended max page size for Jira API
+DEFAULT_MAX_COMMENTS_TO_FETCH: int = 5  # Max recent comments to include full body for
+DEFAULT_COMMENT_MAX_LENGTH: int = 500  # Max length of comment bodies included
+
+# Default fields list
+DEFAULT_FETCH_FIELDS_LIST: List[str] = [
+    "summary",
+    "description",
+    "status",
+    "assignee",
+    "reporter",
+    "priority",
+    "created",
+    "updated",
+    "duedate",
+    "labels",
+    "components",
+    "issuelinks",
+    "comment",  # Epic link field added dynamically in __init__
+]
+
+# --- Setup Logging ---
+logger = logging.getLogger(__name__)
+
+
+# Helper function to make arguments hashable for LRU cache
+def _make_hashable(arg: Any) -> Any:
+    """Make an argument hashable for LRU cache."""
+    if isinstance(arg, list):
+        try:
+            return tuple(sorted(arg))
+        except TypeError:
+            return tuple(arg)
+    if isinstance(arg, set):
+        return tuple(sorted(list(arg)))
+    if isinstance(arg, dict):
+        return tuple(sorted(arg.items()))
+    return arg
+
+
+# Custom cache decorator to handle unhashable arguments
+def hashable_lru_cache(maxsize=128, typed=False):
+    """LRU cache decorator that can handle unhashable arguments."""
+
+    def decorator(func):
+        cached_func = lru_cache(maxsize=maxsize, typed=typed)(func)
+
+        def wrapper(*args, **kwargs):
+            hashable_args = tuple(_make_hashable(arg) for arg in args)
+            hashable_kwargs = {k: _make_hashable(v) for k, v in kwargs.items()}
+            return cached_func(*hashable_args, **hashable_kwargs)
+
+        wrapper.cache_info = cached_func.cache_info
+        wrapper.cache_clear = cached_func.cache_clear
+        return wrapper
+
+    return decorator
+
+
+class JiraUtils:
+    """
+    Utility class for interacting with the Jira API.
+
+    Fetches and processes Jira issues, including epics and links,
+    preparing data for analysis or LLM input.
+    """
+
+    # Use Any type to avoid issues when jira package is not available
+    _client: Optional[Any] = None
+
+    def __init__(
+        self,
+        user_email: Optional[str] = None,
+        api_token: Optional[str] = None,
+        jira_url: Optional[str] = None,
+        epic_link_field_id: Optional[str] = None,
+        fetch_fields: Optional[List[str]] = None,
+    ):
+        """Initialize JiraUtils.
+
+        Args:
+            user_email: Email associated with the Jira API token.
+                Falls back to JIRA_USER_EMAIL env var.
+            api_token: Jira API token (PAT). Falls back to JIRA_API_TOKEN env var.
+            jira_url: URL of the Jira instance. Falls back to JIRA_URL env var
+                or DEFAULT_JIRA_URL.
+            epic_link_field_id: The custom field ID for the Epic link.
+                Falls back to JIRA_EPIC_LINK_FIELD_ID env var or
+                DEFAULT_EPIC_LINK_FIELD_ID constant.
+            fetch_fields: List of fields to fetch for issues. Defaults to a comprehensive list.
+
+        Raises:
+            ValueError: If required authentication details are missing.
+        """
+        if not _JIRA_AVAILABLE:
+            raise ImportError(
+                "The 'jira' package is required but not installed. "
+                "Please install it with 'pip install jira'."
+            )
+
+        # Try to load from .env using dotenv if available
+        try:
+            from dotenv import load_dotenv
+
+            load_dotenv()
+        except ImportError:
+            pass  # Continue without dotenv
+
+        self.user_email = user_email or os.getenv("JIRA_USER_EMAIL")
+        self.api_token = api_token or os.getenv("JIRA_API_TOKEN")
+        self.jira_url = jira_url or os.getenv("JIRA_URL") or DEFAULT_JIRA_URL
+
+        # Allow empty string env var to override default
+        _env_epic_field = os.getenv("JIRA_EPIC_LINK_FIELD_ID")
+        self.epic_link_field_id = (
+            epic_link_field_id
+            if epic_link_field_id is not None
+            else _env_epic_field
+            if _env_epic_field is not None
+            else DEFAULT_EPIC_LINK_FIELD_ID
+        )
+
+        # Validate essential configuration
+        if not self.user_email:
+            raise ValueError(
+                "Jira user email is required (provide via arg or JIRA_USER_EMAIL env var)."
+            )
+        if not self.api_token:
+            raise ValueError(
+                "Jira API token is required (provide via arg or JIRA_API_TOKEN env var)."
+            )
+        if not self.jira_url:
+            raise ValueError("Jira URL is required (provide via arg or JIRA_URL env var).")
+
+        # Configure fields to fetch
+        _default_fields: List[str] = DEFAULT_FETCH_FIELDS_LIST[:]  # Create a copy
+        if self.epic_link_field_id not in _default_fields:
+            _default_fields.append(self.epic_link_field_id)
+
+        # Use provided fetch_fields or the computed default list
+        effective_fetch_fields = fetch_fields if fetch_fields is not None else _default_fields
+
+        # Ensure base fields required for processing are always included
+        _required_base_fields = {"key", "summary", "status", "issuelinks", "comment"}
+        self.fetch_fields: List[str] = list(set(effective_fetch_fields) | _required_base_fields)
+        # Store as a sorted tuple for consistent use in cached functions
+        self.fetch_fields_tuple: Tuple[str, ...] = tuple(sorted(self.fetch_fields))
+
+        logger.info(f"JiraUtils initialized for URL: {self.jira_url} with user: {self.user_email}")
+        # Client is initialized lazily via the 'client' property
+
+    @property
+    def client(self) -> JIRA:
+        """Lazy-initialized, authenticated jira.JIRA client."""
+        if self._client is None:
+            logger.info(f"Connecting to Jira at {self.jira_url}...")
+            try:
+                self._client = JIRA(
+                    server=self.jira_url,
+                    basic_auth=(self.user_email, self.api_token),
+                )
+                logger.info(f"Successfully connected to Jira as {self.user_email}.")
+            except JIRAError as e:
+                logger.error(
+                    f"Jira connection failed: Status {e.status_code} - {e.text}", exc_info=True
+                )
+                raise RuntimeError(f"Failed to connect to Jira: {e.text}") from e
+            except Exception as e:
+                logger.error(
+                    f"An unexpected error occurred during Jira connection: {e}", exc_info=True
+                )
+                raise RuntimeError(f"Unexpected error connecting to Jira: {str(e)}") from e
+        return self._client
+
+    def _fetch_paginated_issues(
+        self, jql: str, max_results: Optional[int] = None, fields: Optional[Sequence[str]] = None
+    ) -> List[Issue]:
+        """Internal helper to fetch issues using pagination."""
+        issues_batch: List[Issue] = []
+        start_at = 0
+        total_fetched = 0
+        # Use instance default fields tuple if None provided
+        fields_to_fetch_seq = fields if fields is not None else self.fetch_fields_tuple
+        # Convert sequence to comma-separated string for the API call
+        fields_str = ",".join(fields_to_fetch_seq)
+        # Ensure key is always present
+        if "key" not in fields_to_fetch_seq:
+            fields_str = "key," + fields_str
+
+        effective_page_size = DEFAULT_MAX_RESULTS_PER_PAGE
+
+        while True:
+            num_to_fetch = effective_page_size
+            if max_results is not None:
+                remaining_needed = max_results - total_fetched
+                if remaining_needed <= 0:
+                    break
+                num_to_fetch = min(effective_page_size, remaining_needed)
+
+            logger.debug(
+                f"Fetching issues with JQL: '{jql}', startAt: {start_at}, maxResults: {num_to_fetch}"
+            )
+            try:
+                current_batch = self.client.search_issues(
+                    jql,
+                    startAt=start_at,
+                    maxResults=num_to_fetch,
+                    fields=fields_str,
+                    json_result=False,
+                )
+            except JIRAError as e:
+                logger.error(
+                    f"JQL query failed: '{jql}'. Status: {e.status_code} - {e.text}", exc_info=True
+                )
+                raise
+            except Exception as e:
+                logger.error(f"Unexpected error fetching issues: {e}", exc_info=True)
+                raise RuntimeError(f"Unexpected error fetching issues: {str(e)}") from e
+
+            batch_size = len(current_batch)
+            issues_batch.extend(current_batch)
+            total_fetched += batch_size
+            logger.debug(
+                f"Fetched {batch_size} issues in this batch. Total fetched: {total_fetched}"
+            )
+
+            if batch_size < num_to_fetch or (
+                max_results is not None and total_fetched >= max_results
+            ):
+                break
+            start_at += batch_size
+
+        logger.info(
+            f"Finished fetching for JQL '{jql}'. Total issues retrieved: {len(issues_batch)}"
+        )
+        return issues_batch
+
+    def fetch_tickets_raw(
+        self, jql: str, max_results: Optional[int] = None, fields: Optional[Sequence[str]] = None
+    ) -> List[Issue]:
+        """Fetch raw jira.Issue objects based on JQL."""
+        logger.info(
+            f"Fetching raw tickets for JQL: {jql}"
+            + (f" (max: {max_results})" if max_results else "")
+        )
+        fields_to_fetch = fields if fields is not None else self.fetch_fields_tuple
+        return self._fetch_paginated_issues(jql, max_results, fields_to_fetch)
+
+    @hashable_lru_cache(maxsize=256)
+    def fetch_single_ticket_raw(
+        self, ticket_key: str, fields: Optional[Sequence[str]] = None
+    ) -> Issue:
+        """Fetch a single raw jira.Issue object by key (cached)."""
+        logger.debug(f"Fetching single raw ticket: {ticket_key}")
+        fields_to_fetch_seq = fields if fields is not None else self.fetch_fields_tuple
+        fields_str = ",".join(fields_to_fetch_seq)
+
+        if "key" not in fields_to_fetch_seq:
+            fields_str = "key," + fields_str
+
+        normalized_key = ticket_key.upper()
+
+        try:
+            issue = self.client.issue(normalized_key, fields=fields_str)
+            logger.debug(f"Successfully fetched raw ticket: {normalized_key}")
+            return issue
+        except JIRAError as e:
+            logger.warning(
+                f"Failed to fetch ticket {normalized_key}: Status {e.status_code} - {e.text}",
+                exc_info=False,
+            )
+            raise
+        except Exception as e:
+            logger.error(f"Unexpected error fetching ticket {normalized_key}: {e}", exc_info=True)
+            raise RuntimeError(
+                f"Unexpected error fetching ticket {normalized_key}: {str(e)}"
+            ) from e
+
+    def _get_field_value(self, issue: Issue, field_name: str, default: Any = None) -> Any:
+        """Safely retrieve a field value from an issue."""
+        try:
+            value = getattr(issue.fields, field_name, default)
+            return value if value is not None else default
+        except AttributeError:
+            logger.debug(
+                f"AttributeError accessing field '{field_name}' on issue {issue.key}. Returning default."
+            )
+            return default
+
+    def _get_display_name(self, user_object: Optional[Any], default: str = "Unknown User") -> str:
+        """Safely extract the displayName from a Jira user object."""
+        if user_object:
+            if hasattr(user_object, "displayName") and user_object.displayName:
+                return user_object.displayName
+            if hasattr(user_object, "name") and user_object.name:
+                return user_object.name
+        return default
+
+    def _get_epic_info(self, issue: Issue) -> Tuple[Optional[str], Optional[str]]:
+        """Extract the Epic key and summary from an issue, if linked."""
+        epic_key: Optional[str] = self._get_field_value(issue, self.epic_link_field_id)
+
+        if not epic_key:
+            return None, None
+
+        epic_summary: Optional[str] = None
+        try:
+            epic_fields_tuple = ("summary",)
+            epic_issue = self.fetch_single_ticket_raw(epic_key, fields=epic_fields_tuple)
+            epic_summary = self._get_field_value(epic_issue, "summary", default=f"Epic {epic_key}")
+            logger.debug(f"Found Epic link for {issue.key}: {epic_key} ('{epic_summary}')")
+        except JIRAError:
+            logger.warning(
+                f"Could not fetch details for Epic {epic_key} linked from {issue.key}.",
+                exc_info=False,
+            )
+            epic_summary = f"Epic {epic_key} (details unavailable)"
+        except Exception as e:
+            logger.error(f"Unexpected error fetching epic {epic_key} details: {e}", exc_info=True)
+            epic_summary = f"Epic {epic_key} (error fetching details)"
+
+        return epic_key, epic_summary
+
+    def _get_issue_links(self, issue: Issue) -> List[Dict[str, Any]]:
+        """Extract and process all issue links from an issue."""
+        processed_links: List[Dict[str, Any]] = []
+        raw_links = self._get_field_value(issue, "issuelinks", default=[])
+
+        if not raw_links:
+            return processed_links
+
+        logger.debug(f"Processing {len(raw_links)} links for issue {issue.key}")
+        linked_issue_fields_tuple = ("summary", "status")
+
+        for link in raw_links:
+            link_data: Dict[str, Any] = {}
+            try:
+                link_type_obj = getattr(link, "type", None)
+                if not link_type_obj:
+                    logger.warning(f"Link object in issue {issue.key} missing 'type'. Skipping.")
+                    continue
+
+                linked_issue_obj = None
+                direction = None
+
+                # Determine direction and link type name
+                if hasattr(link, "outwardIssue"):
+                    direction = "outward"
+                    linked_issue_obj = link.outwardIssue
+                    link_data["type"] = getattr(link_type_obj, "outward", "Unknown Outward Type")
+                elif hasattr(link, "inwardIssue"):
+                    direction = "inward"
+                    linked_issue_obj = link.inwardIssue
+                    link_data["type"] = getattr(link_type_obj, "inward", "Unknown Inward Type")
+                else:
+                    logger.warning(
+                        f"Link object in issue {issue.key} has no inward or outward issue. Skipping."
+                    )
+                    continue
+
+                if not linked_issue_obj or not hasattr(linked_issue_obj, "key"):
+                    logger.warning(
+                        f"Link object in issue {issue.key} missing linked issue key. Skipping."
+                    )
+                    continue
+
+                linked_key = linked_issue_obj.key
+                link_data["direction"] = direction
+                link_data["key"] = linked_key
+
+                # Fetch summary and status of the linked issue (cached)
+                linked_summary: Optional[str] = f"Issue {linked_key}"
+                linked_status: Optional[str] = "Unknown"
+                try:
+                    linked_issue_details = self.fetch_single_ticket_raw(
+                        linked_key, fields=linked_issue_fields_tuple
+                    )
+                    linked_summary = self._get_field_value(
+                        linked_issue_details, "summary", default=linked_summary
+                    )
+                    status_obj = self._get_field_value(linked_issue_details, "status")
+                    linked_status = (
+                        status_obj.name
+                        if status_obj and hasattr(status_obj, "name")
+                        else linked_status
+                    )
+                except JIRAError:
+                    logger.warning(
+                        f"Could not fetch details for linked issue {linked_key}.", exc_info=False
+                    )
+                    linked_summary += " (details unavailable)"
+                except Exception as e:
+                    logger.error(
+                        f"Unexpected error fetching linked issue {linked_key} details: {e}",
+                        exc_info=True,
+                    )
+                    linked_summary += " (error fetching details)"
+
+                link_data["summary"] = linked_summary
+                link_data["status"] = linked_status
+
+                processed_links.append(link_data)
+                logger.debug(f"Processed link from {issue.key}: {link_data}")
+
+            except AttributeError as e:
+                logger.warning(
+                    f"AttributeError processing link in issue {issue.key}: {e}", exc_info=False
+                )
+            except Exception as e:
+                logger.error(
+                    f"Unexpected error processing a link in issue {issue.key}: {e}", exc_info=True
+                )
+
+        return processed_links
+
+    def _get_comments_summary(
+        self,
+        issue: Issue,
+        max_comments_to_fetch: int = DEFAULT_MAX_COMMENTS_TO_FETCH,
+        max_length: int = DEFAULT_COMMENT_MAX_LENGTH,
+    ) -> Dict[str, Any]:
+        """Extract comments summary and a limited list of recent comments."""
+        comments_field = self._get_field_value(issue, "comment", default=None)
+        all_comments: List[JiraCommentResource] = []
+        if comments_field and hasattr(comments_field, "comments"):
+            all_comments = comments_field.comments
+        else:
+            logger.debug(f"No comments found or comment field malformed for issue {issue.key}")
+            return {
+                "total_count": 0,
+                "fetched_count": 0,
+                "unique_commenters": 0,
+                "commenter_stats": [],
+                "fetched_comments": [],
+            }
+
+        total_count = len(all_comments)
+        logger.debug(f"Processing {total_count} total comments for issue {issue.key}")
+
+        commenter_data: Dict[str, Dict[str, int]] = defaultdict(
+            lambda: {"count": 0, "total_chars": 0}
+        )
+        authors: Set[str] = set()
+
+        for comment in all_comments:
+            author_name = self._get_display_name(
+                getattr(comment, "author", None), default="Unknown User"
+            )
+            authors.add(author_name)
+            body_length = len(getattr(comment, "body", ""))
+            commenter_data[author_name]["count"] += 1
+            commenter_data[author_name]["total_chars"] += body_length
+
+        unique_commenters = len(authors)
+
+        commenter_stats = sorted(
+            [
+                {
+                    "author": author,
+                    "comment_count": stats["count"],
+                    "total_chars": stats["total_chars"],
+                }
+                for author, stats in commenter_data.items()
+            ],
+            key=lambda x: x["comment_count"],
+            reverse=True,
+        )
+
+        fetched_comments: List[Dict[str, Any]] = []
+        comments_to_process = (
+            all_comments[-max_comments_to_fetch:] if max_comments_to_fetch > 0 else []
+        )
+        fetched_count = len(comments_to_process)
+
+        for comment in comments_to_process:
+            author_name = self._get_display_name(
+                getattr(comment, "author", None), default="Unknown User"
+            )
+            body = getattr(comment, "body", "")
+            truncated_body = (
+                (body[:max_length] + "..." if len(body) > max_length else body)
+                if max_length >= 0
+                else body
+            )
+            created_iso = None
+            try:
+                created_dt = getattr(comment, "created", None)
+                if created_dt and hasattr(created_dt, "isoformat"):
+                    created_iso = created_dt.isoformat()
+                elif isinstance(created_dt, str):
+                    created_iso = created_dt
+            except Exception as e:
+                logger.error(f"Error formatting created date for comment: {e}", exc_info=False)
+
+            fetched_comments.append(
+                {"author": author_name, "body": truncated_body, "created": created_iso}
+            )
+
+        return {
+            "total_count": total_count,
+            "fetched_count": fetched_count,
+            "unique_commenters": unique_commenters,
+            "commenter_stats": commenter_stats,
+            "fetched_comments": fetched_comments,
+        }
+
+    def process_issue_details(self, issue: Issue) -> Dict[str, Any]:
+        """Transform a raw jira.Issue object into a structured dictionary."""
+        logger.debug(f"Processing details for issue: {issue.key}")
+
+        status_obj = self._get_field_value(issue, "status")
+        assignee_obj = self._get_field_value(issue, "assignee")
+        reporter_obj = self._get_field_value(issue, "reporter")
+        priority_obj = self._get_field_value(issue, "priority")
+        components_list = self._get_field_value(issue, "components", default=[])
+        labels_list = self._get_field_value(issue, "labels", default=[])
+
+        epic_key, epic_summary = self._get_epic_info(issue)
+        links = self._get_issue_links(issue)
+        comments_summary = self._get_comments_summary(issue)
+
+        def format_iso_date(field_name: str) -> Optional[str]:
+            date_val = self._get_field_value(issue, field_name)
+            if not date_val:
+                return None
+            if hasattr(date_val, "isoformat"):
+                return date_val.isoformat()
+            # Try to handle string dates (e.g., YYYY-MM-DD from some fields)
+            if isinstance(date_val, str):
+                return date_val
+            logger.warning(f"Could not format date field '{field_name}' for issue {issue.key}")
+            return str(date_val)  # Fallback to string representation
+
+        details = {
+            "key": issue.key,
+            "url": issue.permalink(),
+            "summary": self._get_field_value(issue, "summary", default=""),
+            "description": self._get_field_value(issue, "description"),
+            "status": status_obj.name if status_obj and hasattr(status_obj, "name") else "Unknown",
+            "assignee": self._get_display_name(assignee_obj, default="Unassigned"),
+            "reporter": self._get_display_name(reporter_obj),
+            "priority": (
+                priority_obj.name if priority_obj and hasattr(priority_obj, "name") else None
+            ),
+            "created_date": format_iso_date("created"),
+            "updated_date": format_iso_date("updated"),
+            "due_date": format_iso_date("duedate"),
+            "labels": labels_list,  # Keep as list for JSON
+            "components": [
+                comp.name for comp in components_list if hasattr(comp, "name")
+            ],  # Keep as list for JSON
+            "epic_key": epic_key,
+            "epic_summary": epic_summary,
+            "links": links,  # Keep detailed structure for JSON
+            "comments_summary": comments_summary,  # Keep detailed structure for JSON
+        }
+        logger.debug(f"Finished processing details for issue: {issue.key}")
+        return details
+
+    def fetch_processed_tickets(
+        self, jql: str, max_results: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Fetch issues based on JQL and return them as processed dictionaries."""
+        logger.info(
+            f"Fetching and processing tickets for JQL: {jql}"
+            + (f" (max: {max_results})" if max_results else "")
+        )
+        raw_issues = self.fetch_tickets_raw(
+            jql, max_results=max_results, fields=self.fetch_fields_tuple
+        )
+
+        processed_tickets: List[Dict[str, Any]] = []
+        for issue in raw_issues:
+            try:
+                processed_details = self.process_issue_details(issue)
+                processed_tickets.append(processed_details)
+            except Exception as e:
+                logger.error(f"Failed to process issue {issue.key}: {e}", exc_info=True)
+                processed_tickets.append(
+                    {
+                        "key": issue.key,
+                        "url": issue.permalink(),
+                        "summary": "Error processing issue",
+                        "error": f"Failed to process issue details: {str(e)}",
+                    }
+                )
+
+        logger.info(
+            f"Successfully fetched and processed {len(processed_tickets)} tickets for JQL: {jql}"
+        )
+        return processed_tickets
+
+    def fetch_processed_ticket(self, ticket_key: str) -> Dict[str, Any]:
+        """Fetch a single issue by key and return it as a processed dictionary."""
+        logger.info(f"Fetching and processing single ticket: {ticket_key}")
+        try:
+            raw_issue = self.fetch_single_ticket_raw(ticket_key, fields=self.fetch_fields_tuple)
+            processed_ticket = self.process_issue_details(raw_issue)
+            logger.info(f"Successfully fetched and processed ticket: {ticket_key}")
+            return processed_ticket
+        except (JIRAError, RuntimeError) as e:
+            logger.error(f"Failed to fetch or process ticket {ticket_key}: {e}", exc_info=True)
+            raise
+
+    def format_tickets_for_llm(
+        self,
+        tickets: List[Dict[str, Any]],
+        include_description: bool = False,
+        description_length: int = 300,
+        include_comments: bool = True,
+    ) -> str:
+        """Format processed tickets into a concise Markdown string for LLM input."""
+        output_lines: List[str] = []
+        output_lines.append(f"# Jira Ticket Summary ({len(tickets)} issues)\n")
+
+        for ticket in tickets:
+            if "error" in ticket:  # Handle tickets that failed processing
+                output_lines.append(
+                    f"## [{ticket.get('key', 'N/A')}] - Error processing this ticket\n"
+                )
+                output_lines.append(f"*   Error details: {ticket['error']}")
+                output_lines.append("\n---\n")
+                continue
+
+            output_lines.append(
+                f"## [{ticket.get('key', 'N/A')}] {ticket.get('summary', 'No Summary')}\n"
+            )
+            output_lines.append(f"*   **Status:** {ticket.get('status', 'Unknown')}")
+            output_lines.append(f"*   **Assignee:** {ticket.get('assignee', 'Unassigned')}")
+            if ticket.get("priority"):
+                output_lines.append(f"*   **Priority:** {ticket['priority']}")
+            if ticket.get("due_date"):
+                output_lines.append(f"*   **Due:** {ticket['due_date'][:10]}")
+            if ticket.get("epic_key"):
+                output_lines.append(
+                    f"*   **Epic:** [{ticket['epic_key']}] {ticket.get('epic_summary', '')}"
+                )
+            if ticket.get("components"):
+                output_lines.append(f"*   **Components:** {', '.join(ticket['components'])}")
+            if ticket.get("labels"):
+                output_lines.append(f"*   **Labels:** {', '.join(ticket['labels'])}")
+
+            if include_description and ticket.get("description"):
+                desc = ticket["description"]
+                truncated_desc = (
+                    desc[:description_length] + "..." if len(desc) > description_length else desc
+                )
+                formatted_desc = truncated_desc.replace("\r\n", "\n").replace("\n", "\n    ")
+                output_lines.append(
+                    f"\n*   **Description:**\n    ```\n    {formatted_desc}\n    ```"
+                )
+
+            if ticket.get("links"):
+                links = ticket["links"]
+                link_summary = defaultdict(list)
+                for link in links:
+                    link_text = f"[{link.get('key', 'N/A')}] ({link.get('status', '?')})"
+                    link_summary[link.get("type", "Link").capitalize()].append(link_text)
+                output_lines.append("\n*   **Links:**")
+                for link_type, linked_items in link_summary.items():
+                    output_lines.append(f"    *   {link_type}: {', '.join(linked_items)}")
+
+            if include_comments and ticket.get("comments_summary"):
+                c_summary = ticket["comments_summary"]
+                output_lines.append(
+                    f"\n*   **Comments:** {c_summary.get('total_count', 0)} total by {c_summary.get('unique_commenters', 0)} people."
+                )
+                top_commenters = [
+                    f"{stat['author']} ({stat['comment_count']})"
+                    for stat in c_summary.get("commenter_stats", [])[:3]
+                ]
+                if top_commenters:
+                    output_lines.append(f"    *   Top commenters: {', '.join(top_commenters)}")
+                recent_comments = c_summary.get("fetched_comments", [])
+                if recent_comments:
+                    output_lines.append("    *   Recent comments:")
+                    for comment in recent_comments:
+                        author = comment.get("author", "Unknown")
+                        date_str = comment.get("created", "")[:10] if comment.get("created") else ""
+                        body_snippet = comment.get("body", "").replace("\n", " ").replace("\r", "")
+                        output_lines.append(f'        *   {date_str} ({author}): "{body_snippet}"')
+
+            output_lines.append("\n---\n")
+
+        return "\n".join(output_lines)
+
+    def close(self) -> None:
+        """Close the Jira client connection resources."""
+        if self._client:
+            logger.info("Closing Jira client connection.")
+            try:
+                self._client.close()
+                self._client = None
+                logger.info("Jira client connection closed.")
+            except Exception as e:
+                logger.warning(f"Error encountered while closing Jira client: {e}", exc_info=False)
+                self._client = None
+        else:
+            logger.debug("Jira client already closed or was never initialized.")
+
+    def __enter__(self):
+        """Context manager entry point."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit point. Ensures the client connection is closed."""
+        self.close()

--- a/cellmage/version.py
+++ b/cellmage/version.py
@@ -2,7 +2,7 @@ _MAJOR = "0"
 _MINOR = "2"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "4"
+_PATCH = "5"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,6 +8,7 @@
 installation
 overview
 ipython_magic_commands
+jira_integration
 ```
 
 ```{toctree}

--- a/docs/source/jira_integration.md
+++ b/docs/source/jira_integration.md
@@ -78,6 +78,7 @@ After loading a Jira ticket with `%jira`, you can refer to it in your LLM prompt
 %jira PROJECT-123
 
 # Then ask the LLM about it
+# The %%llm magic starts a new cell in Jupyter notebooks
 %%llm
 Given the Jira ticket above, what are the key requirements I need to implement?
 ```

--- a/docs/source/jira_integration.md
+++ b/docs/source/jira_integration.md
@@ -1,0 +1,85 @@
+# Jira Integration
+
+CellMage provides integration with Jira through the `%jira` magic command, allowing you to fetch Jira tickets directly into your notebook and use them as context for LLM queries.
+
+## Installation
+
+To use the Jira integration, install CellMage with the `jira` extra:
+
+```bash
+pip install cellmage[jira]
+```
+
+## Configuration
+
+The Jira integration requires the following environment variables:
+
+- `JIRA_URL`: The URL of your Jira instance (e.g., `https://your-company.atlassian.net`)
+- `JIRA_USER_EMAIL`: The email address associated with your Jira account
+- `JIRA_API_TOKEN`: Your Jira API token/personal access token (PAT)
+
+You can set these in a `.env` file in your working directory or directly in your environment.
+
+## Using the `%jira` Magic Command
+
+### Basic Usage
+
+To fetch a specific ticket:
+
+```python
+%jira PROJECT-123
+```
+
+This fetches the ticket and adds it as a user message in the chat history.
+
+### Using JQL Queries
+
+You can also use JQL (Jira Query Language) to fetch multiple tickets:
+
+```python
+%jira --jql 'project = PROJECT AND assignee = currentUser() ORDER BY updated DESC' --max 3
+```
+
+### Command Options
+
+- `--jql "query"`: Use a JQL query to fetch multiple tickets
+- `--max N`: Limit the number of tickets returned by a JQL query (default: 5)
+- `--system`: Add tickets as system messages instead of user messages
+- `--show`: Only display the tickets without adding them to the chat history
+
+### Examples
+
+Fetch a ticket and add it to history:
+```python
+%jira PROJECT-123
+```
+
+Fetch a ticket and add it as system context:
+```python
+%jira PROJECT-123 --system
+```
+
+Just view a ticket without adding to history:
+```python
+%jira PROJECT-123 --show
+```
+
+Fetch your recent tickets:
+```python
+%jira --jql 'assignee = currentUser() ORDER BY updated DESC' --max 5
+```
+
+## Using Jira Tickets with LLM Queries
+
+After loading a Jira ticket with `%jira`, you can refer to it in your LLM prompts:
+
+```python
+# First, fetch a ticket
+%jira PROJECT-123
+
+# Then ask the LLM about it
+%%llm
+Given the Jira ticket above, what are the key requirements I need to implement?
+```
+
+This allows you to use Jira tickets as context for your LLM queries, making it easier to work with project-specific information.

--- a/docs/source/jira_integration.md
+++ b/docs/source/jira_integration.md
@@ -76,9 +76,11 @@ After loading a Jira ticket with `%jira`, you can refer to it in your LLM prompt
 ```python
 # First, fetch a ticket
 %jira PROJECT-123
+```
 
-# Then ask the LLM about it
-# The %%llm magic starts a new cell in Jupyter notebooks
+Then in a new cell, you can ask the LLM about it:
+
+```
 %%llm
 Given the Jira ticket above, what are the key requirements I need to implement?
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ langchain = [
     "langchain-community>=0.1.20",
     "langchain-openai>=0.0.8"
 ]
+jira = [
+    "jira>=3.5.0",
+    "python-dotenv>=1.0.0"
+]
 dev = [
     "ruff",
     "mypy>=1.0,<2.0",

--- a/tests/integration/test_jira_magic.py
+++ b/tests/integration/test_jira_magic.py
@@ -1,0 +1,107 @@
+"""
+Test the Jira magic command.
+"""
+
+import unittest.mock as mock
+
+import pytest
+from IPython.core.interactiveshell import InteractiveShell
+from IPython.testing.globalipapp import start_ipython
+
+# Skip tests if jira module is not available
+pytest.importorskip("jira")
+
+
+@pytest.fixture
+def ip():
+    """Start a test IPython kernel."""
+    return start_ipython()
+
+
+def test_jira_magic_loads(ip):
+    """Test that the Jira magic command loads correctly."""
+    # Load the extension
+    ip.run_cell("%load_ext cellmage.integrations.jira_magic")
+
+    # Check that the magic command is registered
+    assert "jira" in ip.magics_manager.magics["line"]
+
+
+@mock.patch("cellmage.integrations.jira_magic.JiraMagics._fetch_ticket")
+def test_jira_fetch_ticket(mock_fetch_ticket, ip):
+    """Test fetch_ticket functionality."""
+    # Mock the fetch_ticket method to return a dummy ticket
+    mock_ticket = {
+        "key": "TEST-123",
+        "summary": "Test ticket",
+        "description": "This is a test description",
+        "status": "Open",
+        "assignee": "Test User",
+        "reporter": "Another User",
+    }
+    mock_fetch_ticket.return_value = mock_ticket
+
+    # Load the extension
+    ip.run_cell("%load_ext cellmage.integrations.jira_magic")
+
+    # Run the magic command
+    result = ip.run_line_magic("jira", "TEST-123 --show")
+
+    # Check that the fetch_ticket method was called with the correct ticket key
+    mock_fetch_ticket.assert_called_once_with("TEST-123")
+
+
+@mock.patch("cellmage.integrations.jira_magic.JiraMagics._fetch_tickets_by_jql")
+def test_jira_fetch_by_jql(mock_fetch_by_jql, ip):
+    """Test fetch_tickets_by_jql functionality."""
+    # Mock the fetch_tickets_by_jql method to return dummy tickets
+    mock_tickets = [
+        {
+            "key": "TEST-123",
+            "summary": "Test ticket 1",
+            "description": "Description 1",
+            "status": "Open",
+        },
+        {
+            "key": "TEST-124",
+            "summary": "Test ticket 2",
+            "description": "Description 2",
+            "status": "In Progress",
+        },
+    ]
+    mock_fetch_by_jql.return_value = mock_tickets
+
+    # Load the extension
+    ip.run_cell("%load_ext cellmage.integrations.jira_magic")
+
+    # Run the magic command with JQL
+    jql_query = "project = TEST AND assignee = currentUser()"
+    result = ip.run_line_magic("jira", f'--jql "{jql_query}" --max 2 --show')
+
+    # Check that the fetch_tickets_by_jql method was called with the correct arguments
+    mock_fetch_by_jql.assert_called_once_with(jql_query, max_results=2)
+
+
+@mock.patch("cellmage.integrations.jira_magic.JiraMagics._add_ticket_to_history")
+@mock.patch("cellmage.integrations.jira_magic.JiraMagics._fetch_ticket")
+def test_jira_add_to_history(mock_fetch_ticket, mock_add_to_history, ip):
+    """Test adding a ticket to history."""
+    # Mock the fetch_ticket method to return a dummy ticket
+    mock_ticket = {
+        "key": "TEST-123",
+        "summary": "Test ticket",
+        "description": "This is a test description",
+        "status": "Open",
+    }
+    mock_fetch_ticket.return_value = mock_ticket
+    mock_add_to_history.return_value = True
+
+    # Load the extension
+    ip.run_cell("%load_ext cellmage.integrations.jira_magic")
+
+    # Run the magic command with system flag
+    result = ip.run_line_magic("jira", "TEST-123 --system")
+
+    # Check that the methods were called with the correct arguments
+    mock_fetch_ticket.assert_called_once_with("TEST-123")
+    mock_add_to_history.assert_called_once_with(mock_ticket, as_system_msg=True)

--- a/tests/integration/test_jira_magic.py
+++ b/tests/integration/test_jira_magic.py
@@ -5,7 +5,6 @@ Test the Jira magic command.
 import unittest.mock as mock
 
 import pytest
-from IPython.core.interactiveshell import InteractiveShell
 from IPython.testing.globalipapp import start_ipython
 
 # Skip tests if jira module is not available
@@ -45,7 +44,7 @@ def test_jira_fetch_ticket(mock_fetch_ticket, ip):
     ip.run_cell("%load_ext cellmage.integrations.jira_magic")
 
     # Run the magic command
-    result = ip.run_line_magic("jira", "TEST-123 --show")
+    ip.run_line_magic("jira", "TEST-123 --show")
 
     # Check that the fetch_ticket method was called with the correct ticket key
     mock_fetch_ticket.assert_called_once_with("TEST-123")
@@ -76,7 +75,7 @@ def test_jira_fetch_by_jql(mock_fetch_by_jql, ip):
 
     # Run the magic command with JQL
     jql_query = "project = TEST AND assignee = currentUser()"
-    result = ip.run_line_magic("jira", f'--jql "{jql_query}" --max 2 --show')
+    ip.run_line_magic("jira", f'--jql "{jql_query}" --max 2 --show')
 
     # Check that the fetch_tickets_by_jql method was called with the correct arguments
     mock_fetch_by_jql.assert_called_once_with(jql_query, max_results=2)
@@ -100,7 +99,7 @@ def test_jira_add_to_history(mock_fetch_ticket, mock_add_to_history, ip):
     ip.run_cell("%load_ext cellmage.integrations.jira_magic")
 
     # Run the magic command with system flag
-    result = ip.run_line_magic("jira", "TEST-123 --system")
+    ip.run_line_magic("jira", "TEST-123 --system")
 
     # Check that the methods were called with the correct arguments
     mock_fetch_ticket.assert_called_once_with("TEST-123")


### PR DESCRIPTION
- Implemented `JiraUtils` class for interacting with the Jira API, including methods for fetching and processing tickets, handling comments, and managing issue links.
- Added `%jira` magic command to fetch Jira tickets directly into notebooks, supporting both single ticket retrieval and JQL queries.
- Created documentation for Jira integration, detailing installation, configuration, and usage examples for the magic command.
- Developed integration tests for the Jira magic command to ensure functionality and reliability.

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
-

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/madpin/cellmage/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/madpin/cellmage/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
