### PR TITLE
Implement timeline-based history rollback for cell reruns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.9.8](https://github.com/madpin/cellmage/releases/tag/v0.9.8) - 2025-05-23
+
+### Added
+- Implemented timeline-based history rollback to enable reverting cell states during reruns.
+- Added token counting utilities and refactored related handlers to improve token management.
+
+### Changed
+- Replaced `history_manager` with `conversation_manager` throughout the codebase to unify management components.
+
+### Fixed
+- Fixed the `%gdocs` cell rerun behavior to remove the previously added document and replace it with the new cell content, resolving issue #31.
+
+
 ## [v0.9.7](https://github.com/madpin/cellmage/releases/tag/v0.9.7) - 2025-05-20
 
 ### Added

--- a/cellmage/chat_manager.py
+++ b/cellmage/chat_manager.py
@@ -300,8 +300,8 @@ class ChatManager:
             self.logger.debug(f"Cell ID: {cell_id}")
 
         # Check for auto rollback
-        if auto_rollback and cell_id is not None:
-            self.conversation_manager.perform_rollback(cell_id)
+        if auto_rollback and cell_id is not None: # exec_count can be None if not from a cell
+            self.conversation_manager.perform_rollback(cell_id, exec_count)
 
         try:
             # If persona_name is provided, try to load and set it temporarily

--- a/cellmage/chat_manager.py
+++ b/cellmage/chat_manager.py
@@ -300,7 +300,7 @@ class ChatManager:
             self.logger.debug(f"Cell ID: {cell_id}")
 
         # Check for auto rollback
-        if auto_rollback and cell_id is not None: # exec_count can be None if not from a cell
+        if auto_rollback and cell_id is not None:  # exec_count can be None if not from a cell
             self.conversation_manager.perform_rollback(cell_id, exec_count)
 
         try:

--- a/cellmage/conversation_manager.py
+++ b/cellmage/conversation_manager.py
@@ -160,9 +160,7 @@ class ConversationManager:
         """
         # 1. Determine current_cell_id and current_cell_exec_count
         if self.context_provider:
-            exec_count_from_ctx, cell_id_from_ctx = (
-                self.context_provider.get_execution_context()
-            )
+            exec_count_from_ctx, cell_id_from_ctx = self.context_provider.get_execution_context()
             if current_cell_id is None:
                 current_cell_id = cell_id_from_ctx
             if current_cell_exec_count is None:
@@ -203,7 +201,7 @@ class ConversationManager:
             for i, msg in enumerate(self.messages):
                 if msg.cell_id is not None:
                     self.cell_last_message_index[msg.cell_id] = i
-            
+
             # Save changes to database
             self._save_current_conversation()  # Ensure conversation state is persisted
 

--- a/cellmage/magic_commands/tools/base_tool_magic.py
+++ b/cellmage/magic_commands/tools/base_tool_magic.py
@@ -125,31 +125,9 @@ class BaseMagics(Magics):
             # Get execution context to identify current cell
             exec_count, cell_id = self._get_execution_context()
 
-            # Find and remove any previous content from the same source
-            if hasattr(manager, "conversation_manager"):
-                # Get current history
-                current_history = manager.conversation_manager.get_messages()
-
-                # Look for messages to remove based on their metadata
-                indices_to_remove = self._find_messages_to_remove(
-                    current_history, source_name, source_type, source_id, id_key
-                )
-
-                # If we found messages to remove
-                if indices_to_remove:
-                    # Create a new history without those messages
-                    new_history = [
-                        msg for i, msg in enumerate(current_history) if i not in indices_to_remove
-                    ]
-
-                    # Clear history and re-add the filtered messages
-                    manager.conversation_manager.clear_messages(keep_system=False)
-                    for msg in new_history:
-                        manager.conversation_manager.add_message(msg)
-
-                    logger.info(
-                        f"Removed {len(indices_to_remove)} previous {source_name} {source_type} messages"
-                    )
+            # Perform rollback if necessary
+            if manager and hasattr(manager, "conversation_manager") and manager.conversation_manager and cell_id:
+                manager.conversation_manager.perform_rollback(cell_id, exec_count)
 
             # Create message with execution context
             role = "system" if as_system_msg else "user"
@@ -174,36 +152,3 @@ class BaseMagics(Magics):
             logger.error(f"Error adding {source_name} content to history: {e}")
             print(f"❌ Error adding {source_name} content to history: {e}")
             return False
-
-    def _find_messages_to_remove(
-        self, history: List, source_name: str, source_type: str, source_id: str, id_key: str
-    ) -> List[int]:
-        """
-        Find messages to remove from history based on source metadata.
-
-        This is a base implementation that should be overridden by subclasses
-        for more specific removal strategies.
-
-        Args:
-            history: The current message history
-            source_name: Name of the source system
-            source_type: Type of the content
-            source_id: ID of the content
-            id_key: Key used for the source ID in metadata
-
-        Returns:
-            List of indices to remove
-        """
-        indices_to_remove = []
-
-        # Basic implementation: remove exact matches
-        for i, msg in enumerate(history):
-            if (
-                msg.metadata
-                and msg.metadata.get("source") == source_name
-                and msg.metadata.get("type") == source_type
-                and msg.metadata.get(id_key) == source_id
-            ):
-                indices_to_remove.append(i)
-
-        return indices_to_remove

--- a/cellmage/magic_commands/tools/base_tool_magic.py
+++ b/cellmage/magic_commands/tools/base_tool_magic.py
@@ -6,7 +6,7 @@ This module provides a base class with common functionality for all magic comman
 
 import logging
 import uuid
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 try:
     from IPython.core.magic import Magics, magics_class
@@ -126,7 +126,12 @@ class BaseMagics(Magics):
             exec_count, cell_id = self._get_execution_context()
 
             # Perform rollback if necessary
-            if manager and hasattr(manager, "conversation_manager") and manager.conversation_manager and cell_id:
+            if (
+                manager
+                and hasattr(manager, "conversation_manager")
+                and manager.conversation_manager
+                and cell_id
+            ):
                 manager.conversation_manager.perform_rollback(cell_id, exec_count)
 
             # Create message with execution context

--- a/cellmage/magic_commands/tools/dummy_magic.py
+++ b/cellmage/magic_commands/tools/dummy_magic.py
@@ -1,0 +1,39 @@
+from IPython.core.magic import Magics, magics_class, line_magic, cell_magic
+from .base_tool_magic import BaseMagics
+
+@magics_class
+class DummyToolMagic(BaseMagics):
+
+    @line_magic
+    def dummytool(self, line):
+        """A dummy line magic that adds its input to history."""
+        content = f"DummyTool Line Magic Output: {line}"
+        # Use the _add_to_history method from BaseMagics
+        # The source_type, source_id, source_name, and id_key can be generic for this dummy tool
+        self._add_to_history(
+            content=content,
+            source_type="dummy_tool_line",
+            source_id=line, # Use line content as a simple ID
+            source_name="dummytool",
+            id_key="dummy_tool_id",
+            as_system_msg=False # Or True, depending on how you want to test
+        )
+        print(content) # Also print to notebook for immediate feedback
+
+    @cell_magic
+    def dummymagiccell(self, line, cell):
+        """A dummy cell magic that adds its input to history."""
+        content = f"DummyTool Cell Magic Output: {line}\n{cell}"
+        # Use the _add_to_history method from BaseMagics
+        self._add_to_history(
+            content=content,
+            source_type="dummy_tool_cell",
+            source_id=line, # Use line content as a simple ID
+            source_name="dummytoolcell",
+            id_key="dummy_tool_cell_id",
+            as_system_msg=False # Or True
+        )
+        print(content) # Also print to notebook
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(DummyToolMagic)

--- a/cellmage/magic_commands/tools/dummy_magic.py
+++ b/cellmage/magic_commands/tools/dummy_magic.py
@@ -1,5 +1,7 @@
-from IPython.core.magic import Magics, magics_class, line_magic, cell_magic
+from IPython.core.magic import cell_magic, line_magic, magics_class
+
 from .base_tool_magic import BaseMagics
+
 
 @magics_class
 class DummyToolMagic(BaseMagics):
@@ -13,12 +15,12 @@ class DummyToolMagic(BaseMagics):
         self._add_to_history(
             content=content,
             source_type="dummy_tool_line",
-            source_id=line, # Use line content as a simple ID
+            source_id=line,  # Use line content as a simple ID
             source_name="dummytool",
             id_key="dummy_tool_id",
-            as_system_msg=False # Or True, depending on how you want to test
+            as_system_msg=False,  # Or True, depending on how you want to test
         )
-        print(content) # Also print to notebook for immediate feedback
+        print(content)  # Also print to notebook for immediate feedback
 
     @cell_magic
     def dummymagiccell(self, line, cell):
@@ -28,12 +30,13 @@ class DummyToolMagic(BaseMagics):
         self._add_to_history(
             content=content,
             source_type="dummy_tool_cell",
-            source_id=line, # Use line content as a simple ID
+            source_id=line,  # Use line content as a simple ID
             source_name="dummytoolcell",
             id_key="dummy_tool_cell_id",
-            as_system_msg=False # Or True
+            as_system_msg=False,  # Or True
         )
-        print(content) # Also print to notebook
+        print(content)  # Also print to notebook
+
 
 def load_ipython_extension(ipython):
     ipython.register_magics(DummyToolMagic)

--- a/cellmage/version.py
+++ b/cellmage/version.py
@@ -2,7 +2,7 @@ _MAJOR = "0"
 _MINOR = "9"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "7"
+_PATCH = "8"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""

--- a/tests/timeline_testing.ipynb
+++ b/tests/timeline_testing.ipynb
@@ -1,0 +1,558 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext cellmage.magic_commands.ipython.llm_magic\n",
+    "%load_ext cellmage.magic_commands.ipython.config_magic\n",
+    "%load_ext cellmage.magic_commands.tools.dummy_magic\n",
+    "\n",
+    "# Setup to see history\n",
+    "from IPython import get_ipython\n",
+    "ip = get_ipython()\n",
+    "\n",
+    "# Ensure _cellmage_chat_manager is initialized by running a config magic or similar\n",
+    "try:\n",
+    "    ip.run_line_magic('llm_config', '') \n",
+    "except Exception as e:\n",
+    "    print(f\"Error running llm_config to ensure ChatManager init: {e}\")\n",
+    "\n",
+    "chat_manager = ip.user_ns.get('_cellmage_chat_manager')\n",
+    "\n",
+    "def print_history():\n",
+    "    print(\"--- Conversation History ---\")\n",
+    "    if not chat_manager or not hasattr(chat_manager, 'conversation_manager') or not chat_manager.conversation_manager:\n",
+    "        print(\"Chat manager or conversation manager not available.\")\n",
+    "        print(\"--------------------------\")\n",
+    "        return\n",
+    "    messages = chat_manager.conversation_manager.get_messages()\n",
+    "    if not messages: \n",
+    "        print(\"History is empty.\")\n",
+    "    else:\n",
+    "        for i, msg in enumerate(messages):\n",
+    "            content_preview = msg.content.replace('\\n', ' ')[:100] if msg.content else \"\"\n",
+    "            print(f\"{i}: [{msg.role.upper()}] (Cell: {msg.cell_id}, Exec: {msg.execution_count}) {content_preview}\")\n",
+    "    print(\"--------------------------\")\n",
+    "\n",
+    "# Initial check and setup for testing\n",
+    "if chat_manager:\n",
+    "    print(\"Chat Manager loaded.\")\n",
+    "    if hasattr(chat_manager, 'conversation_manager') and chat_manager.conversation_manager:\n",
+    "        print(\"Conversation Manager available.\")\n",
+    "        # Start with a fresh conversation for this test run\n",
+    "        chat_manager.conversation_manager.create_new_conversation()\n",
+    "        print(\"New conversation created for testing.\")\n",
+    "    else:\n",
+    "        print(\"Conversation Manager NOT available in ChatManager.\")\n",
+    "else:\n",
+    "    print(\"Chat Manager NOT loaded. History inspection will fail.\")\n",
+    "\n",
+    "print_history() # Initial empty history"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Test Scenario 1 (LLM Magic):**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:01.000Z",
+     "end_time": "2023-10-27T10:00:02.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm\n",
+    "Hello"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:03.000Z",
+     "end_time": "2023-10-27T10:00:04.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm\n",
+    "How are you?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:05.000Z",
+     "end_time": "2023-10-27T10:00:06.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm\n",
+    "Goodbye"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rerun Cell A2 (the one with \"How are you?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:03.000Z",
+     "end_time": "2023-10-27T10:00:07.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm\n",
+    "How are you?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rerun Cell A1 (the one with \"Hello\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:01.000Z",
+     "end_time": "2023-10-27T10:00:08.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm\n",
+    "Hello"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Test Scenario 2 (Tool Magic - using `%dummytool`):**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:09.000Z",
+     "end_time": "2023-10-27T10:00:10.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%dummytool FOO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:11.000Z",
+     "end_time": "2023-10-27T10:00:12.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%dummytool BAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:13.000Z",
+     "end_time": "2023-10-27T10:00:14.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm \n",
+    "Summarize the dummy tools' output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rerun Cell B2 (the one with `%dummytool BAR`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:11.000Z",
+     "end_time": "2023-10-27T10:00:15.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%dummytool BAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rerun Cell B1 (the one with `%dummytool FOO`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:09.000Z",
+     "end_time": "2023-10-27T10:00:16.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%dummytool FOO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Test Scenario 3 (Multiple line magics in one cell):**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:17.000Z",
+     "end_time": "2023-10-27T10:00:18.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%dummytool MULTI_FOO\n",
+    "%dummytool MULTI_BAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:19.000Z",
+     "end_time": "2023-10-27T10:00:20.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm \n",
+    "Query based on MULTI_FOO and MULTI_BAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rerun Cell C1 (the one with multiple dummytool calls)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:17.000Z",
+     "end_time": "2023-10-27T10:00:21.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%dummytool MULTI_FOO\n",
+    "%dummytool MULTI_BAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Test Scenario 4 (Empty or modified cell rerun):**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:22.000Z",
+     "end_time": "2023-10-27T10:00:23.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm \n",
+    "First prompt for D1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:24.000Z",
+     "end_time": "2023-10-27T10:00:25.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm \n",
+    "Second prompt for D2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Modify Cell D1 to be just a Python comment (e.g., `# This cell is now empty`). Rerun Cell D1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:22.000Z",
+     "end_time": "2023-10-27T10:00:26.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# This cell is now empty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Modify Cell D1 to be `%%llm New first prompt for D1`. Rerun Cell D1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-27T10:00:22.000Z",
+     "end_time": "2023-10-27T10:00:27.000Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%llm \n",
+    "New first prompt for D1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_history()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Rerunning a cell with `%gdocs` now removes the previously added document and replaces it with the new cell content. The changes introduce a timeline model for managing chat history, ensuring a clean state for outputs after reruns. The rollback logic has been enhanced to accurately identify and clear messages from previous executions, improving consistency across different magic commands. Fixes #31